### PR TITLE
change subgraph to Perps v2

### DIFF
--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,5 +1,5 @@
 export const OPTIMISM_GRAPH_URL =
-  'https://api.thegraph.com/subgraphs/name/kwenta/optimism-main';
+  'https://api.thegraph.com/subgraphs/name/kwenta/optimism-perps';
 
 export const MARKETS = [
   'sETH',


### PR DESCRIPTION
1) we want to use the v2 subgraph
2) this subgraph will go away at some point so we will need to fork this one, or switch to a hosted one

NOTE: MARKETS still need to be updated